### PR TITLE
Compilation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script:
    - ./rebar3 coveralls send
 
 otp_release:
+   - 25.2
    - 20.3
    - 19.2
    - 18.3

--- a/src/pipe.app.src
+++ b/src/pipe.app.src
@@ -1,7 +1,7 @@
 {application, pipe,
    [
       {description, "process pipe library"},
-      {vsn,         "2.0.1"},
+      {vsn,         "2.0.2"},
       {modules,     []},
       {registered,  []},
       {applications,[

--- a/src/pipe_supervisor.erl
+++ b/src/pipe_supervisor.erl
@@ -143,7 +143,7 @@ code_change(_Vsn, State, _) ->
 
 %%
 %%
-heir(Reason, Pid, #state{opts = Opts} = State) ->
+heir(Reason, Pid, #state{opts = Opts}) ->
    case proplists:get_value(heir, Opts) of
       undefined ->
          ok;


### PR DESCRIPTION
Hi, I fixed the compilation warning about the unused variable State in  `pipe_supervisor:heir/3`

```
===> Compiling pipe
_build/default/lib/pipe/src/pipe_supervisor.erl:146:41: Warning: variable 'State' is unused
```

(OTP 25.2.1, rebar3 v3.19.0)